### PR TITLE
Add OpnPayments (Formerly Omise) mock Charge APIs

### DIFF
--- a/src/apis/opnPayments.test.ts
+++ b/src/apis/opnPayments.test.ts
@@ -1,0 +1,46 @@
+import { expect, test } from "bun:test"
+import { api } from "./test-utils"
+
+test("create charge", async () => {
+  const tester = new OpnPaymentsTester()
+
+  const amount = 300000
+  const currency = "thb"
+  const card = "tokn_test_abc1234567890"
+  const return_uri = "http://localhost:5173/payment/return_uri"
+
+  const result = await tester.createCharge(amount, currency, card, return_uri)
+  expect(result).toMatchObject({
+    object: "charge",
+    id: `chrg_test_${card.split("_").pop()}`,
+    amount: amount,
+    currency: currency,
+    return_uri: return_uri,
+    description: "lorem ipsum",
+    status: "pending",
+    authorized: false,
+    paid: false,
+  })
+})
+
+class OpnPaymentsTester {
+  async createCharge(
+    amount: number,
+    currency: string,
+    card: string,
+    return_uri: string
+  ) {
+    const { data } = await api.POST("/opn-payments/charges", {
+      body: {
+        amount: String(amount),
+        currency,
+        card,
+        return_uri,
+        header: {
+          authorization: "Basic " + btoa("skey_dummy" + ":"),
+        },
+      },
+    })
+    return data
+  }
+}

--- a/src/apis/opnPayments.ts
+++ b/src/apis/opnPayments.ts
@@ -1,0 +1,95 @@
+import { Elysia, t } from "elysia"
+import { defineApi } from "../defineApi"
+// import { EventStore } from "../EventStore"
+
+// interface Events {
+//   charges: {
+//     to: string;
+//     from: string;
+//     text: string;
+//   };
+// }
+
+// function getEventStore(phone: string) {
+//   return new EventStore<Events>(`opn-payment:${phone}`);
+// }
+
+const elysia = new Elysia({
+  prefix: "/opn-payments",
+  tags: ["OpnPayments"],
+}).post(
+  "/charges",
+  async ({ body, set }) => {
+    const { amount, card, currency, return_uri } = body
+    // const eventStore = getEventStore(to);
+    // const topic = `opn-payment:${to}`;
+    // set.headers["x-mockapis-topic"] = topic;
+
+    // const messageId = Math.random().toString(36).substring(2, 15);
+
+    // await eventStore.add("charges", { to, from, text });
+
+    return {
+      object: "charge",
+      id: `chrg_test_${card.split("_").pop()}`,
+      amount: Number(amount),
+      currency: currency,
+      return_uri: return_uri ?? undefined,
+      description: "lorem ipsum",
+      status: "pending",
+      authorized: false,
+      paid: false,
+      created_at: new Date().toISOString(),
+    }
+  },
+  {
+    body: t.Object({
+      amount: t.String(),
+      currency: t.String(),
+      card: t.String(),
+      return_uri: t.Optional(t.String()),
+    }),
+    response: t.Object({
+      object: t.String(),
+      id: t.String(),
+      amount: t.Integer(),
+      currency: t.String(),
+      return_uri: t.Optional(t.String()),
+      description: t.String(),
+      status: t.String(),
+      authorized: t.Boolean(),
+      paid: t.Boolean(),
+      created_at: t.String(),
+    }),
+    detail: { summary: "Create Charge" },
+  }
+)
+// .get(
+//   "/_test/messages",
+//   async ({ query }) => {
+//     const eventLog = getEventStore(query.to);
+//     return (await eventLog.get())
+//       .filter((e) => e.type === "sms")
+//       .map((e) => e.payload);
+//   },
+//   {
+//     query: t.Object({
+//       to: t.String(),
+//     }),
+//     response: t.Array(
+//       t.Object({
+//         to: t.String(),
+//         from: t.String(),
+//         text: t.String(),
+//       })
+//     ),
+//     detail: { summary: "[Test] Get sent SMS messages" },
+//   }
+// );
+
+export const opnPayments = defineApi({
+  tag: "OpnPayments",
+  description:
+    "A mock API that implements a subset of the [OpnPayments API](https://docs.opn.ooo) for receiving payments.",
+  elysia,
+})

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import { line } from "./apis/line";
 import { oauth } from "./apis/oauth";
 import { openai } from "./apis/openai";
 import { vonage } from "./apis/vonage";
+import { opnPayments } from "./apis/opnPayments";
 
 let apiDescription = `**A collection of mock API endpoints of various services,** designed to facilitate end-to-end testing development.
 This project provides a set of simulated APIs that mimic the real services, allowing developers to test their applications without relying on actual external services.
@@ -80,6 +81,7 @@ const apis = [
   line,
   vonage,
   dtinthKio,
+  opnPayments,
 ] as const;
 
 const sortedApis = [...apis].sort((a, b) => a.tag.localeCompare(b.tag));


### PR DESCRIPTION
Will focus on Charges API first https://docs.opn.ooo/charges-api

# Progress

- [x] Create charge
- [ ] List charges
- [ ] Capture charge
- [ ] Reverse charge

Note: Tested with Omise Ruby Client by changing Omise.api_url to `http://localhost:46982/opn-payments`

<img width="891" alt="kitty 2024-10-08 23 44 33" src="https://github.com/user-attachments/assets/3178fb89-7903-4602-b372-c0a28d1e88d1">

