### PR TITLE
Dockerize the service and add docker-compose.yml

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+node_modules/
+.github/
+README.md

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,8 +12,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v2
-      - run: docker compose up -d && bunx wait-on http-get://127.0.0.1:46982/swagger/json
-      - run: bun run generate:types
+      - name: Start service and Redis
+        run: docker compose up -d && bunx wait-on http-get://127.0.0.1:46982/swagger/json
+      - run: bun install && bun run generate:types
       - run: bun test
         env:
           REDIS_URL: redis://localhost:6379

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,16 +9,10 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    services:
-      redis:
-        image: redis
-        ports:
-          - 6379:6379
     steps:
       - uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v2
-      - run: bun install
-      - run: bun run src/index.ts & bunx wait-on http-get://127.0.0.1:46982/swagger/json
+      - run: docker compose up -d && bunx wait-on http-get://127.0.0.1:46982/swagger/json
       - run: bun run generate:types
       - run: bun test
         env:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+# Build stage with src
+FROM oven/bun:1.1 AS builder
+
+WORKDIR /app
+
+COPY package.json bun.lockb ./
+
+RUN bun install
+
+COPY . .
+
+RUN bun build --target=bun --outfile=index.js src
+
+# Actual image without unnecessary files
+FROM oven/bun:1.1
+
+WORKDIR /app
+
+COPY --from=builder /app/node_modules ./node_modules
+COPY --from=builder /app/index.js ./
+
+EXPOSE 46982
+
+CMD [ "bun", "index.js" ]
+

--- a/README.md
+++ b/README.md
@@ -40,6 +40,14 @@ You can explore the available APIs and their documentation at our demo instance:
 
 <https://mockapis.onrender.com/>
 
+## Running with Docker
+
+We provide a docker-compose configuration for users who would like to run the service locally without any configuration. This is useful if you have limitation connecting to external network during testing.
+
+```sh
+docker compose up -d
+```
+
 ## Features
 
 - Multiple mock API endpoints simulating various services without the need for authentication or API keys (any key is accepted)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,23 @@
+version: '3.8'
+
+services:
+  redis:
+    image: "redis:latest"
+    container_name: "redis"
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis-data:/data
+  mockapis:
+    build: .
+    container_name: "mockapis"
+    environment:
+      - REDIS_URL=redis://redis:6379
+    depends_on:
+      - redis
+    ports:
+      - "46982:46982"
+
+volumes:
+  redis-data:
+    driver: local

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   redis:
     image: "redis:latest"


### PR DESCRIPTION
This PR add a `Dockerfile` and `docker-compose.yml` which helps with running the service locally as all user might not be able to call external network during e2e test.