### PR TITLE
fix: change LINE Login token exchange endpoint from GET to POST

### DIFF
--- a/src/apis/line.test.ts
+++ b/src/apis/line.test.ts
@@ -155,15 +155,13 @@ class LineTester {
       redirect_uri: string;
     }
   ) {
-    const { data } = await api.GET("/line/oauth2/v2.1/token", {
-      params: {
-        query: {
-          grant_type: "authorization_code",
-          code,
-          redirect_uri: params.redirect_uri,
-          client_id: params.client_id,
-          client_secret: params.client_secret,
-        },
+    const { data } = await api.POST("/line/oauth2/v2.1/token", {
+      body: {
+        grant_type: "authorization_code",
+        code,
+        redirect_uri: params.redirect_uri,
+        client_id: params.client_id,
+        client_secret: params.client_secret,
       },
     });
     return data!;

--- a/src/apis/line.ts
+++ b/src/apis/line.ts
@@ -134,10 +134,10 @@ const elysia = new Elysia({ prefix: "/line", tags: ["LINE"] })
       detail: { summary: "Get user profile" },
     }
   )
-  .get(
+  .post(
     "/oauth2/v2.1/token",
-    async ({ query }) => {
-      const { code, client_id, client_secret } = query;
+    async ({ body }) => {
+      const { code, client_id, client_secret } = body;
       
       const claims = decodeAuthorizationCode(code);
       
@@ -151,7 +151,7 @@ const elysia = new Elysia({ prefix: "/line", tags: ["LINE"] })
       };
     },
     {
-      query: t.Object({
+      body: t.Object({
         grant_type: t.String(),
         code: t.String(),
         redirect_uri: t.String(),


### PR DESCRIPTION
Fixes the LINE Login token exchange endpoint to use POST method instead of GET, following OAuth 2.0 security standards.

**Changes made:**
- Changed `.get()` to `.post()` for `/oauth2/v2.1/token` endpoint
- Updated parameter handling from query to body
- Updated schema definition accordingly

This ensures sensitive credentials like `client_secret` are sent in the request body rather than URL query parameters, improving security and compliance with OAuth 2.0 standards.

Fixes #21

Generated with [Claude Code](https://claude.ai/code)