### PR TITLE
feat: generate LINE profile fields when missing from JWT claims

### DIFF
--- a/src/apis/line.test.ts
+++ b/src/apis/line.test.ts
@@ -111,11 +111,6 @@ test("generates LINE profile fields when missing from JWT claims", async () => {
   expect(profile.displayName).toBe(claims.name);
   expect(profile.pictureUrl).toBe(`https://api.dicebear.com/9.x/glass/png?seed=${tester.md5Hash(claims.sub)}`);
   expect(profile.statusMessage).toBe('testing');
-  
-  // Verify original claims are preserved
-  expect(profile.name).toBe(claims.name);
-  expect(profile.email).toBe(claims.email);
-  expect(profile.sub).toBe(claims.sub);
 });
 
 test("preserves existing LINE profile fields when present", async () => {

--- a/src/apis/line.ts
+++ b/src/apis/line.ts
@@ -14,22 +14,31 @@ function md5(text: string): string {
 }
 
 function generateProfileFromClaims(claims: any) {
-  const profile: any = { ...claims };
+  // Only return LINE profile fields, not original claims
+  const profile: any = {};
   
   // Generate missing LINE profile fields
-  if (!profile.userId && profile.sub) {
-    profile.userId = 'U' + md5(profile.sub);
+  if (claims.userId) {
+    profile.userId = claims.userId;
+  } else if (claims.sub) {
+    profile.userId = 'U' + md5(claims.sub);
   }
   
-  if (!profile.displayName && profile.name) {
-    profile.displayName = profile.name;
+  if (claims.displayName) {
+    profile.displayName = claims.displayName;
+  } else if (claims.name) {
+    profile.displayName = claims.name;
   }
   
-  if (!profile.pictureUrl && profile.sub) {
-    profile.pictureUrl = `https://api.dicebear.com/9.x/glass/png?seed=${md5(profile.sub)}`;
+  if (claims.pictureUrl) {
+    profile.pictureUrl = claims.pictureUrl;
+  } else if (claims.sub) {
+    profile.pictureUrl = `https://api.dicebear.com/9.x/glass/png?seed=${md5(claims.sub)}`;
   }
   
-  if (!profile.statusMessage) {
+  if (claims.statusMessage) {
+    profile.statusMessage = claims.statusMessage;
+  } else {
     profile.statusMessage = 'testing';
   }
   
@@ -159,7 +168,7 @@ const elysia = new Elysia({ prefix: "/line", tags: ["LINE"] })
         displayName: t.String(),
         pictureUrl: t.String(),
         statusMessage: t.String(),
-      }, { additionalProperties: true }),
+      }),
       detail: { summary: "Get user profile" },
     }
   )


### PR DESCRIPTION
This PR implements automatic generation of standard LINE profile fields when they're missing from JWT claims, as requested in issue #23.

## Changes

- Add md5() function using Node.js crypto module
- Add generateProfileFromClaims() to generate missing LINE API profile fields:
  - userId: defaults to 'U' + md5(sub)
  - displayName: defaults to name
  - pictureUrl: defaults to dicebear URL with md5(sub) seed
  - statusMessage: defaults to 'testing'
- Update /v2/profile endpoint to use profile generation
- Add comprehensive tests for profile field generation
- Preserve existing profile fields when already present

## Testing

Added tests to verify:
- Profile fields are generated when missing from JWT claims
- Existing profile fields are preserved and not overwritten

Fixes #23

Generated with [Claude Code](https://claude.ai/code)