### PR TITLE
Add link to pre-built Docker image in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ You can explore the available APIs and their documentation at our demo instance:
 
 ### Using Pre-built Image
 
-For quick setup without building from source, you can use the pre-built Docker image. Create a `docker-compose.yml` file with the following content:
+For quick setup without building from source, you can use the [pre-built Docker image](https://github.com/dtinth/mockapis/pkgs/container/mockapis). Create a `docker-compose.yml` file with the following content:
 
 ```yaml
 services:


### PR DESCRIPTION
Updated README to include link to pre-built Docker image.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README to include a direct hyperlink to the pre-built Docker image, replacing the previous plain-text reference.
  * Improves discoverability and streamlines setup for users pulling the Docker image.
  * No functional or structural changes to the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->